### PR TITLE
PLF-4685 : Configuration less css for all gadgets in gadget-pack and int...

### DIFF
--- a/plf-shared-assemblies/src/main/resources/assemblies/plf-standalone-default-tomcat-distribution-content.xml
+++ b/plf-shared-assemblies/src/main/resources/assemblies/plf-standalone-default-tomcat-distribution-content.xml
@@ -584,7 +584,7 @@
       <includes>
         <include>org.exoplatform.platform:platform-sample-gadgets-sample-gadgets:war</include>
       </includes>
-      <outputFileNameMapping>intranet-gadget.war</outputFileNameMapping>
+      <outputFileNameMapping>intranet-gadgets.war</outputFileNameMapping>
       <useProjectArtifact>false</useProjectArtifact>
     </dependencySet>
     <!-- Various external wars -->


### PR DESCRIPTION
Please accept this PR. Some resources in gadget projects need the context path root as : "intranet-gadgets" not "intranet-gadget". 
Thank Arnaud. 
