### PR TITLE
Add async support which is needed for cometd to work properly

### DIFF
--- a/plf-tomcat-resources/src/main/resources/conf/context.xml
+++ b/plf-tomcat-resources/src/main/resources/conf/context.xml
@@ -27,6 +27,6 @@
   <!-- Default set of monitored resources -->
   <WatchedResource>WEB-INF/web.xml</WatchedResource>
 
-  <Valve className="org.gatein.sso.agent.tomcat.ServletAccessValve" />
+  <Valve className="org.gatein.sso.agent.tomcat.ServletAccessValve" asyncSupported="true"/>
 
 </Context>


### PR DESCRIPTION
CometD long-polling transport need all valve, filter, servlet to be async, if not, it throw runtime exception.
Step to reproduce:
- run tomcat with -Dexo.cometd.transports=org.cometd.server.transport.JSONTransport
- go to calendar page
--> exceptions raised in server console