### PR TITLE
PLF-6451: Platform fails to start with Turkish locale

### DIFF
--- a/plf-tomcat-resources/src/main/resources/bin/setenv.bat
+++ b/plf-tomcat-resources/src/main/resources/bin/setenv.bat
@@ -63,6 +63,9 @@ IF NOT DEFINED EXO_JVM_USER_REGION SET EXO_JVM_USER_REGION=US
 IF NOT DEFINED EXO_DEBUG SET EXO_DEBUG=false
 IF NOT DEFINED EXO_DEBUG_PORT SET EXO_DEBUG_PORT=8000
 
+REM # PLF-6451: Not use Turkish locale
+IF /I %EXO_JVM_USER_LANGUAGE% EQU tr SET EXO_JVM_USER_LANGUAGE=en
+
 REM # ---------------------------------------------------------------------------
 REM # Default EXO PLATFORM configuration
 REM # ---------------------------------------------------------------------------

--- a/plf-tomcat-resources/src/main/resources/bin/setenv.sh
+++ b/plf-tomcat-resources/src/main/resources/bin/setenv.sh
@@ -57,10 +57,14 @@ fi
 [ -z $EXO_JVM_SIZE_MAX ] && EXO_JVM_SIZE_MAX="3g"
 [ -z $EXO_JVM_SIZE_MIN ] && EXO_JVM_SIZE_MIN="512m"
 [ -z $EXO_JVM_PERMSIZE_MAX ] && EXO_JVM_PERMSIZE_MAX="256m"
-[ -z $EXO_JVM_USER_LANGUAGE ] && EXO_JVM_USER_LANGUAGE="en"
 [ -z $EXO_JVM_USER_REGION ] && EXO_JVM_USER_REGION="US"
 [ -z $EXO_DEBUG ] && EXO_DEBUG=false
 [ -z $EXO_DEBUG_PORT ] && EXO_DEBUG_PORT="8000"
+
+# PLF-6451: Not use Turkish locale
+if [ -z $EXO_JVM_USER_LANGUAGE ] || [ $EXO_JVM_USER_LANGUAGE = "tr" ]; then
+  EXO_JVM_USER_LANGUAGE="en"
+fi
 
 # -----------------------------------------------------------------------------
 # Default EXO PLATFORM configuration


### PR DESCRIPTION
Fix description:
- When JVM locale is Turkish, change it to English.
