### PR TITLE
DEP-105: Exclude old xpp3:xpp3 lib which comes picocontainer:picocontainer

### DIFF
--- a/plf-assemblies/src/main/resources/assemblies/plf-copy-libraries-component.xml
+++ b/plf-assemblies/src/main/resources/assemblies/plf-copy-libraries-component.xml
@@ -68,6 +68,8 @@
         <exclude>jdom:*</exclude>
         <!-- These artifacts are in conflict with others ones under xpp3:xpp3 -->
         <exclude>xpp3:xpp3_min</exclude>
+        <!-- DEP-105: These artifacts are in conflict with others ones under org.ogce:xpp3 -->
+        <exclude>xpp3:xpp3</exclude>
         <!-- These artifact is in conflict with ones under commons-beanutils:commons-beanutils -->
         <exclude>commons-beanutils:commons-beanutils-core</exclude>
         <!-- This artifact is in conflict with the one under org.jboss.logging:jboss-logging -->

--- a/plf-dependencies/pom.xml
+++ b/plf-dependencies/pom.xml
@@ -550,6 +550,11 @@
           <artifactId>log4j</artifactId>
           <groupId>log4j</groupId>
         </exclusion>
+        <!-- DEP-105: Coming by transitivity from picocontainer:picocontainer -->
+        <exclusion>
+          <artifactId>xpp3</artifactId>
+          <groupId>xpp3</groupId>
+        </exclusion>
         <!-- Coming by transitivity from com.thoughtworks.xstream:xstream -->
         <exclusion>
           <artifactId>xpp3_min</artifactId>
@@ -811,6 +816,11 @@
         <exclusion>
           <artifactId>sso-integration</artifactId>
           <groupId>org.gatein.sso</groupId>
+        </exclusion>
+        <!-- DEP-105: Coming by transitivity from picocontainer:picocontainer -->
+        <exclusion>
+          <artifactId>xpp3</artifactId>
+          <groupId>xpp3</groupId>
         </exclusion>
       </exclusions>
     </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -328,8 +328,6 @@
                         <exclude>jdom:*</exclude>
                         <!-- These artifacts are in conflict with others ones under xpp3:xpp3 -->
                         <exclude>xpp3:xpp3_min</exclude>
-                        <!-- DEP-105: These artifacts are in conflict with others ones under org.ogce:xpp3 -->
-                        <exclude>xpp3:xpp3</exclude>
                         <!-- These artifact is in conflict with ones under commons-beanutils:commons-beanutils -->
                         <exclude>commons-beanutils:commons-beanutils-core</exclude>
                         <!-- This artifact is in conflict with the one under org.jboss.logging:jboss-logging -->

--- a/pom.xml
+++ b/pom.xml
@@ -328,6 +328,8 @@
                         <exclude>jdom:*</exclude>
                         <!-- These artifacts are in conflict with others ones under xpp3:xpp3 -->
                         <exclude>xpp3:xpp3_min</exclude>
+                        <!-- DEP-105: These artifacts are in conflict with others ones under org.ogce:xpp3 -->
+                        <exclude>xpp3:xpp3</exclude>
                         <!-- These artifact is in conflict with ones under commons-beanutils:commons-beanutils -->
                         <exclude>commons-beanutils:commons-beanutils-core</exclude>
                         <!-- This artifact is in conflict with the one under org.jboss.logging:jboss-logging -->


### PR DESCRIPTION
Exclude old xpp3:xpp3 lib which comes by transitivity from picocontainer:picocontainer

As the **maven-depmgt-pom** declares a new **xpp3** version (1.1.6) but the groupId xpp3 has changed, we have to exclude the oldest versions to not have both libraries in the PLF packaging.

Note: this PR is related to the https://github.com/exoplatform/maven-depmgt-pom/pull/21 
