### PR TITLE
PLF-6603 : remove leading empty classpath entry

### DIFF
--- a/plf-tomcat-resources/src/main/resources/bin/setenv.bat
+++ b/plf-tomcat-resources/src/main/resources/bin/setenv.bat
@@ -104,7 +104,11 @@ REM # Deactivate j.u.l
 SET LOGGING_MANAGER=-Dnop
 REM # Add additional bootstrap entries for logging purpose using SLF4J+Logback
 REM # SLF4J deps
-SET CLASSPATH=%CLASSPATH%;%CATALINA_HOME%\lib\slf4j-api-${org.slf4j.version}.jar
+IF DEFINED CLASSPATH (
+  SET CLASSPATH=%CLASSPATH%;%CATALINA_HOME%\lib\slf4j-api-${org.slf4j.version}.jar
+) ELSE (
+  SET CLASSPATH=%CATALINA_HOME%\lib\slf4j-api-${org.slf4j.version}.jar
+)
 SET CLASSPATH=%CLASSPATH%;%CATALINA_HOME%\lib\jul-to-slf4j-${org.slf4j.version}.jar
 REM # LogBack deps
 SET CLASSPATH=%CLASSPATH%;%CATALINA_HOME%\lib\logback-core-${ch.qas.logback.version}.jar

--- a/plf-tomcat-resources/src/main/resources/bin/setenv.sh
+++ b/plf-tomcat-resources/src/main/resources/bin/setenv.sh
@@ -103,7 +103,11 @@ JAVA_OPTS="$JAVA_OPTS -DEXO_TOMCAT_UNPACK_WARS=${EXO_TOMCAT_UNPACK_WARS} -DEXO_D
 LOGGING_MANAGER="-Dnop"
 # Add additional bootstrap entries for logging purpose using SLF4J+Logback
 # SLF4J deps
-CLASSPATH="$CLASSPATH":"$CATALINA_HOME/lib/slf4j-api-${org.slf4j.version}.jar"
+if [ ! -z $CLASSPATH ]; then
+  CLASSPATH="$CLASSPATH":"$CATALINA_HOME/lib/slf4j-api-${org.slf4j.version}.jar"
+else
+  CLASSPATH="$CATALINA_HOME/lib/slf4j-api-${org.slf4j.version}.jar"
+fi
 CLASSPATH="$CLASSPATH":"$CATALINA_HOME/lib/jul-to-slf4j-${org.slf4j.version}.jar"
 # LogBack deps
 CLASSPATH="$CLASSPATH":"$CATALINA_HOME/lib/logback-core-${ch.qas.logback.version}.jar"


### PR DESCRIPTION
This fix removes the leading empty classpath entry.
It has not been tested on Windows yet.
