### PR TITLE
PLF-6639 : do not add MaxPermSize option anymore since we do not support Java 7 anymore

### DIFF
--- a/plf-tomcat-resources/src/main/resources/bin/setenv.bat
+++ b/plf-tomcat-resources/src/main/resources/bin/setenv.bat
@@ -137,13 +137,7 @@ SET CATALINA_OPTS=%CATALINA_OPTS% -Dexo.jcr.session.tracking.active=%EXO_JCR_SES
 
 SET CATALINA_OPTS=%CATALINA_OPTS% -Xms%EXO_JVM_SIZE_MIN% -Xmx%EXO_JVM_SIZE_MAX%
 
-REM # PLF-6510: Configure the JVM according to the version
-java.exe -jar %CATALINA_HOME%\bin\exo-tools.jar isJava8OrSuperior
-IF NOT ERRORLEVEL 0 (
-  SET CATALINA_OPTS=%CATALINA_OPTS% -XX:MaxPermSize=%EXO_JVM_PERMSIZE_MAX%
-) ELSE (
-  SET CATALINA_OPTS=%CATALINA_OPTS% -XX:MaxMetaspaceSize=%EXO_JVM_METASPACE_SIZE_MAX%
-)
+SET CATALINA_OPTS=%CATALINA_OPTS% -XX:MaxMetaspaceSize=%EXO_JVM_METASPACE_SIZE_MAX%
 
 REM # Reduce the RMI GCs to once per hour for Sun JVMs.
 SET CATALINA_OPTS=%CATALINA_OPTS% -Dsun.rmi.dgc.client.gcInterval=3600000 -Dsun.rmi.dgc.server.gcInterval=3600000

--- a/plf-tomcat-resources/src/main/resources/bin/setenv.sh
+++ b/plf-tomcat-resources/src/main/resources/bin/setenv.sh
@@ -136,13 +136,7 @@ CATALINA_OPTS="$CATALINA_OPTS -Dexo.jcr.session.tracking.active=${EXO_JCR_SESSIO
 # JVM memory allocation pool parameters
 CATALINA_OPTS="$CATALINA_OPTS -Xms${EXO_JVM_SIZE_MIN} -Xmx${EXO_JVM_SIZE_MAX}"
 
-# PLF-6510: Configure the JVM according to the version
-cmd=$(java -jar $CATALINA_HOME/bin/exo-tools.jar isJava8OrSuperior)
-if [ $? = 0 ]; then
-  CATALINA_OPTS="$CATALINA_OPTS -XX:MaxMetaspaceSize=${EXO_JVM_METASPACE_SIZE_MAX}"
-else
-  CATALINA_OPTS="$CATALINA_OPTS -XX:MaxPermSize=${EXO_JVM_PERMSIZE_MAX}"
-fi
+CATALINA_OPTS="$CATALINA_OPTS -XX:MaxMetaspaceSize=${EXO_JVM_METASPACE_SIZE_MAX}"
 
 # Reduce the RMI GCs to once per hour for Sun JVMs.
 CATALINA_OPTS="$CATALINA_OPTS -Dsun.rmi.dgc.client.gcInterval=3600000 -Dsun.rmi.dgc.server.gcInterval=3600000"


### PR DESCRIPTION
Only JDK 8 is supported in PLF 4.4, so this PR removes the JVM option MaxPermSize.
