### PR TITLE
PLF-6641 : install the addon exo-es-embedded by default in community edition

### DIFF
--- a/plf-assemblies/src/main/resources/assemblies/plf-standalone-tomcat-zip.xml
+++ b/plf-assemblies/src/main/resources/assemblies/plf-standalone-tomcat-zip.xml
@@ -36,6 +36,8 @@
         <exclude>**/temp/*</exclude>
         <exclude>**/logs/*</exclude>
         <exclude>**/work/*</exclude>
+        <exclude>addons/archives/**</exclude>
+        <exclude>addons/catalogs/**</exclude>
       </excludes>
     </fileSet>
   </fileSets>

--- a/plf-community-tomcat-standalone/pom.xml
+++ b/plf-community-tomcat-standalone/pom.xml
@@ -157,6 +157,27 @@
           </dependency>
         </dependencies>
       </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-antrun-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>install-add-ons</id>
+            <phase>prepare-package</phase>
+            <goals>
+              <goal>run</goal>
+            </goals>
+            <configuration>
+              <target name="install-add-ons">
+                <echo message="Installing add-ons..." />
+                <exec dir="${project.basedir}" executable="${project.build.directory}/${project.build.finalName}/${project.build.finalName}/addon${addon.manager.extension}" failonerror="true">
+                  <arg line="install ${addon.exo.es.embedded.id}:${addon.exo.es.embedded.version}" />
+                </exec>
+              </target>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
   </build>
   <profiles>

--- a/pom.xml
+++ b/pom.xml
@@ -82,6 +82,13 @@
     <!-- ************** -->
     <!-- maven-release-plugin -->
     <preparationGoals>clean install</preparationGoals>
+    <!-- ************** -->
+    <!-- Add-ons for Community packaging   -->
+    <!-- ************** -->
+    <addon.exo.es.embedded.id>exo-es-embedded</addon.exo.es.embedded.id>
+    <addon.exo.es.embedded.version>1.0.x-SNAPSHOT</addon.exo.es.embedded.version>
+    <!-- Add-on manager extension to use (empty for Unix, .bat for Windows) -->
+    <addon.manager.extension />
   </properties>
   <dependencyManagement>
     <dependencies>


### PR DESCRIPTION
This PR uses the addon manager at build time to install the Elastic Embedded addon by default in the platform.
