### PR TITLE
PLF-7286 : change log level for logger org.apache.catalina.realm.JAASRealm to avoid displaying a stacktrace for each failed login

### DIFF
--- a/plf-tomcat-resources/src/main/resources/conf/logback.xml
+++ b/plf-tomcat-resources/src/main/resources/conf/logback.xml
@@ -92,6 +92,7 @@ For more details see : http://logback.qos.ch/manual/configuration.html
   <logger name="org.apache.shindig" level="WARN" />
   <logger name="com.google.javascript.jscomp" level="WARN" />
   <logger name="org.apache.tomcat.util.digester.Digester" level="ERROR" />
+  <logger name="org.apache.catalina.realm.JAASRealm" level="ERROR"/>
   <logger name="org.cometd.websocket.server" level="WARN" />
   <if condition='"true".equals(property("EXO_LOGS_DISPLAY_CONSOLE"))'>
     <then>


### PR DESCRIPTION
Throwing an exception is expecting when there is a login failure, as defined in [JAAS doc](http://docs.oracle.com/javase/8/docs/technotes/guides/security/jaas/JAASLMDevGuide.html). The exception is logged by Tomcat (we do not have this behavior with JBoss), so the best and simplest thing to do is to change the log level of JAAS class to ERROR.