### PR TITLE
PLF-7927 allow to have site name with 3 characters

### DIFF
--- a/plf-packaging-resources/src/main/resources/controller.xml
+++ b/plf-packaging-resources/src/main/resources/controller.xml
@@ -52,7 +52,7 @@
     <request-param qname="gtn:token" name="token" value-mapping="never-empty"/>
     <request-param qname="gtn:initURL" name="initURL" value-mapping="never-empty"/>
     <request-param qname="gtn:lang" name="lang" value-mapping="never-empty">
-      <pattern>([A-Za-z]{2,3}(-[A-Za-z]{2})?)?</pattern>
+      <pattern>(ar|ar_AE|ar_BH|ar_DZ|ar_EG|ar_IQ|ar_JO|ar_KW|ar_LB|ar_LY|ar_MA|ar_OM|ar_QA|ar_SA|ar_SD|ar_SY|ar_TN|ar_YE|be|be_BY|bg|bg_BG|ca|ca_ES|cs|cs_CZ|da|da_DK|de|de_AT|de_CH|de_DE|de_GR|de_LU|el|el_CY|el_GR|en|en_AU|en_CA|en_GB|en_IE|en_IN|en_MT|en_NZ|en_PH|en_SG|en_US|en_ZA|es|es_AR|es_BO|es_CL|es_CO|es_CR|es_CU|es_DO|es_EC|es_ES|es_GT|es_HN|es_MX|es_NI|es_PA|es_PE|es_PR|es_PY|es_SV|es_US|es_UY|es_VE|et|et_EE|fa|fi|fi_FI|fil|fr|fr_BE|fr_CA|fr_CH|fr_FR|fr_LU|ga|ga_IE|hi|hi_IN|hr|hr_HR|hu|hu_HU|in|in_ID|is|is_IS|it|it_CH|it_IT|iw|iw_IL|ja|ja_JP|ja_JP_JP_#u-ca-japanese|ko|ko_KR|lt|lt_LT|lv|lv_LV|mk|mk_MK|ms|ms_MY|mt|mt_MT|nl|nl_BE|nl_NL|no|no_NO|no_NO_NY|pl|pl_PL|pt|pt_BR|pt_PT|ro|ro_RO|ru|ru_RU|sk|sk_SK|sl|sl_SI|sq|sq_AL|sr|sr_BA|sr_BA_#Latn|sr_CS|sr_ME|sr_ME_#Latn|sr_RS|sr_RS_#Latn|sr__#Latn|sv|sv_SE|th|th_TH|th_TH_TH_#u-nu-thai|tr|tr_TR|uk|uk_UA|vi|vi_VN|zh|zh_CN|zh_HK|zh_SG|zh_TW)?</pattern>
     </request-param>
   </route>
 
@@ -150,7 +150,7 @@
         <value>portal</value>
       </route-param>
       <path-param qname="gtn:lang" encoding="preserve-path">
-        <pattern>([A-Za-z]{2,3}(-[A-Za-z]{2})?)?</pattern>
+        <pattern>(ar|ar_AE|ar_BH|ar_DZ|ar_EG|ar_IQ|ar_JO|ar_KW|ar_LB|ar_LY|ar_MA|ar_OM|ar_QA|ar_SA|ar_SD|ar_SY|ar_TN|ar_YE|be|be_BY|bg|bg_BG|ca|ca_ES|cs|cs_CZ|da|da_DK|de|de_AT|de_CH|de_DE|de_GR|de_LU|el|el_CY|el_GR|en|en_AU|en_CA|en_GB|en_IE|en_IN|en_MT|en_NZ|en_PH|en_SG|en_US|en_ZA|es|es_AR|es_BO|es_CL|es_CO|es_CR|es_CU|es_DO|es_EC|es_ES|es_GT|es_HN|es_MX|es_NI|es_PA|es_PE|es_PR|es_PY|es_SV|es_US|es_UY|es_VE|et|et_EE|fa|fi|fi_FI|fil|fr|fr_BE|fr_CA|fr_CH|fr_FR|fr_LU|ga|ga_IE|hi|hi_IN|hr|hr_HR|hu|hu_HU|in|in_ID|is|is_IS|it|it_CH|it_IT|iw|iw_IL|ja|ja_JP|ja_JP_JP_#u-ca-japanese|ko|ko_KR|lt|lt_LT|lv|lv_LV|mk|mk_MK|ms|ms_MY|mt|mt_MT|nl|nl_BE|nl_NL|no|no_NO|no_NO_NY|pl|pl_PL|pt|pt_BR|pt_PT|ro|ro_RO|ru|ru_RU|sk|sk_SK|sl|sl_SI|sq|sq_AL|sr|sr_BA|sr_BA_#Latn|sr_CS|sr_ME|sr_ME_#Latn|sr_RS|sr_RS_#Latn|sr__#Latn|sv|sv_SE|th|th_TH|th_TH_TH_#u-nu-thai|tr|tr_TR|uk|uk_UA|vi|vi_VN|zh|zh_CN|zh_HK|zh_SG|zh_TW)?</pattern>
       </path-param>
       <path-param qname="gtn:path" encoding="preserve-path">
         <pattern>.*</pattern>
@@ -170,7 +170,7 @@
     <!-- The group access -->
     <route path="/g/{gtn:sitename}/{gtn:path}">
       <request-param qname="gtn:lang" name="lang" value-mapping="never-empty">
-        <pattern>([A-Za-z]{2,3}(-[A-Za-z]{2})?)?</pattern>
+        <pattern>(ar|ar_AE|ar_BH|ar_DZ|ar_EG|ar_IQ|ar_JO|ar_KW|ar_LB|ar_LY|ar_MA|ar_OM|ar_QA|ar_SA|ar_SD|ar_SY|ar_TN|ar_YE|be|be_BY|bg|bg_BG|ca|ca_ES|cs|cs_CZ|da|da_DK|de|de_AT|de_CH|de_DE|de_GR|de_LU|el|el_CY|el_GR|en|en_AU|en_CA|en_GB|en_IE|en_IN|en_MT|en_NZ|en_PH|en_SG|en_US|en_ZA|es|es_AR|es_BO|es_CL|es_CO|es_CR|es_CU|es_DO|es_EC|es_ES|es_GT|es_HN|es_MX|es_NI|es_PA|es_PE|es_PR|es_PY|es_SV|es_US|es_UY|es_VE|et|et_EE|fa|fi|fi_FI|fil|fr|fr_BE|fr_CA|fr_CH|fr_FR|fr_LU|ga|ga_IE|hi|hi_IN|hr|hr_HR|hu|hu_HU|in|in_ID|is|is_IS|it|it_CH|it_IT|iw|iw_IL|ja|ja_JP|ja_JP_JP_#u-ca-japanese|ko|ko_KR|lt|lt_LT|lv|lv_LV|mk|mk_MK|ms|ms_MY|mt|mt_MT|nl|nl_BE|nl_NL|no|no_NO|no_NO_NY|pl|pl_PL|pt|pt_BR|pt_PT|ro|ro_RO|ru|ru_RU|sk|sk_SK|sl|sl_SI|sq|sq_AL|sr|sr_BA|sr_BA_#Latn|sr_CS|sr_ME|sr_ME_#Latn|sr_RS|sr_RS_#Latn|sr__#Latn|sv|sv_SE|th|th_TH|th_TH_TH_#u-nu-thai|tr|tr_TR|uk|uk_UA|vi|vi_VN|zh|zh_CN|zh_HK|zh_SG|zh_TW)?</pattern>
       </request-param>
       <route-param qname="gtn:sitetype">
         <value>group</value>
@@ -183,7 +183,7 @@
     <!-- The user access -->
     <route path="/u/{gtn:sitename}/{gtn:path}">
       <request-param qname="gtn:lang" name="lang" value-mapping="never-empty">
-        <pattern>([A-Za-z]{2,3}(-[A-Za-z]{2})?)?</pattern>
+        <pattern>(ar|ar_AE|ar_BH|ar_DZ|ar_EG|ar_IQ|ar_JO|ar_KW|ar_LB|ar_LY|ar_MA|ar_OM|ar_QA|ar_SA|ar_SD|ar_SY|ar_TN|ar_YE|be|be_BY|bg|bg_BG|ca|ca_ES|cs|cs_CZ|da|da_DK|de|de_AT|de_CH|de_DE|de_GR|de_LU|el|el_CY|el_GR|en|en_AU|en_CA|en_GB|en_IE|en_IN|en_MT|en_NZ|en_PH|en_SG|en_US|en_ZA|es|es_AR|es_BO|es_CL|es_CO|es_CR|es_CU|es_DO|es_EC|es_ES|es_GT|es_HN|es_MX|es_NI|es_PA|es_PE|es_PR|es_PY|es_SV|es_US|es_UY|es_VE|et|et_EE|fa|fi|fi_FI|fil|fr|fr_BE|fr_CA|fr_CH|fr_FR|fr_LU|ga|ga_IE|hi|hi_IN|hr|hr_HR|hu|hu_HU|in|in_ID|is|is_IS|it|it_CH|it_IT|iw|iw_IL|ja|ja_JP|ja_JP_JP_#u-ca-japanese|ko|ko_KR|lt|lt_LT|lv|lv_LV|mk|mk_MK|ms|ms_MY|mt|mt_MT|nl|nl_BE|nl_NL|no|no_NO|no_NO_NY|pl|pl_PL|pt|pt_BR|pt_PT|ro|ro_RO|ru|ru_RU|sk|sk_SK|sl|sl_SI|sq|sq_AL|sr|sr_BA|sr_BA_#Latn|sr_CS|sr_ME|sr_ME_#Latn|sr_RS|sr_RS_#Latn|sr__#Latn|sv|sv_SE|th|th_TH|th_TH_TH_#u-nu-thai|tr|tr_TR|uk|uk_UA|vi|vi_VN|zh|zh_CN|zh_HK|zh_SG|zh_TW)?</pattern>
       </request-param>
       <route-param qname="gtn:sitetype">
         <value>user</value>
@@ -199,7 +199,7 @@
         <value>portal</value>
       </route-param>
       <path-param qname="gtn:lang" encoding="preserve-path">
-        <pattern>([A-Za-z]{2,3}(-[A-Za-z]{2})?)?</pattern>
+        <pattern>(ar|ar_AE|ar_BH|ar_DZ|ar_EG|ar_IQ|ar_JO|ar_KW|ar_LB|ar_LY|ar_MA|ar_OM|ar_QA|ar_SA|ar_SD|ar_SY|ar_TN|ar_YE|be|be_BY|bg|bg_BG|ca|ca_ES|cs|cs_CZ|da|da_DK|de|de_AT|de_CH|de_DE|de_GR|de_LU|el|el_CY|el_GR|en|en_AU|en_CA|en_GB|en_IE|en_IN|en_MT|en_NZ|en_PH|en_SG|en_US|en_ZA|es|es_AR|es_BO|es_CL|es_CO|es_CR|es_CU|es_DO|es_EC|es_ES|es_GT|es_HN|es_MX|es_NI|es_PA|es_PE|es_PR|es_PY|es_SV|es_US|es_UY|es_VE|et|et_EE|fa|fi|fi_FI|fil|fr|fr_BE|fr_CA|fr_CH|fr_FR|fr_LU|ga|ga_IE|hi|hi_IN|hr|hr_HR|hu|hu_HU|in|in_ID|is|is_IS|it|it_CH|it_IT|iw|iw_IL|ja|ja_JP|ja_JP_JP_#u-ca-japanese|ko|ko_KR|lt|lt_LT|lv|lv_LV|mk|mk_MK|ms|ms_MY|mt|mt_MT|nl|nl_BE|nl_NL|no|no_NO|no_NO_NY|pl|pl_PL|pt|pt_BR|pt_PT|ro|ro_RO|ru|ru_RU|sk|sk_SK|sl|sl_SI|sq|sq_AL|sr|sr_BA|sr_BA_#Latn|sr_CS|sr_ME|sr_ME_#Latn|sr_RS|sr_RS_#Latn|sr__#Latn|sv|sv_SE|th|th_TH|th_TH_TH_#u-nu-thai|tr|tr_TR|uk|uk_UA|vi|vi_VN|zh|zh_CN|zh_HK|zh_SG|zh_TW)?</pattern>
       </path-param>
       <path-param qname="gtn:path" encoding="preserve-path">
         <pattern>.*</pattern>
@@ -221,7 +221,7 @@
         <pattern>.+?</pattern>
       </path-param>
       <path-param qname="gtn:lang" capture-group="true">
-        <pattern>-([A-Za-z]{2,3}(-[A-Za-z]{2})?)|</pattern>
+        <pattern>-((ar|ar_AE|ar_BH|ar_DZ|ar_EG|ar_IQ|ar_JO|ar_KW|ar_LB|ar_LY|ar_MA|ar_OM|ar_QA|ar_SA|ar_SD|ar_SY|ar_TN|ar_YE|be|be_BY|bg|bg_BG|ca|ca_ES|cs|cs_CZ|da|da_DK|de|de_AT|de_CH|de_DE|de_GR|de_LU|el|el_CY|el_GR|en|en_AU|en_CA|en_GB|en_IE|en_IN|en_MT|en_NZ|en_PH|en_SG|en_US|en_ZA|es|es_AR|es_BO|es_CL|es_CO|es_CR|es_CU|es_DO|es_EC|es_ES|es_GT|es_HN|es_MX|es_NI|es_PA|es_PE|es_PR|es_PY|es_SV|es_US|es_UY|es_VE|et|et_EE|fa|fi|fi_FI|fil|fr|fr_BE|fr_CA|fr_CH|fr_FR|fr_LU|ga|ga_IE|hi|hi_IN|hr|hr_HR|hu|hu_HU|in|in_ID|is|is_IS|it|it_CH|it_IT|iw|iw_IL|ja|ja_JP|ja_JP_JP_#u-ca-japanese|ko|ko_KR|lt|lt_LT|lv|lv_LV|mk|mk_MK|ms|ms_MY|mt|mt_MT|nl|nl_BE|nl_NL|no|no_NO|no_NO_NY|pl|pl_PL|pt|pt_BR|pt_PT|ro|ro_RO|ru|ru_RU|sk|sk_SK|sl|sl_SI|sq|sq_AL|sr|sr_BA|sr_BA_#Latn|sr_CS|sr_ME|sr_ME_#Latn|sr_RS|sr_RS_#Latn|sr__#Latn|sv|sv_SE|th|th_TH|th_TH_TH_#u-nu-thai|tr|tr_TR|uk|uk_UA|vi|vi_VN|zh|zh_CN|zh_HK|zh_SG|zh_TW)?)|</pattern>
       </path-param>
       <path-param qname="gtn:compress" capture-group="true">
         <pattern>-(min)|</pattern>


### PR DESCRIPTION
A site with 3 characters is interpreted with previous regex as a language and so the site couldn't be accessed.
This PR will embed the list of possible languages in the regex to not mix sitename with language.
(As long term solution, the ExoRouter should be improved to make it possible to add pattern on language without regex)