### PR TITLE
SWF-4230: Avoid addon artifacts being included in the distributio…

### DIFF
--- a/plf-assemblies/src/main/resources/assemblies/plf-copy-libraries-component.xml
+++ b/plf-assemblies/src/main/resources/assemblies/plf-copy-libraries-component.xml
@@ -98,6 +98,8 @@
         <exclude>org.icepdf:icepdf-core:*</exclude>
         <!-- COR-338: Exclude Apache poi-ooxml 3.8. Platform uses now 3.8-eXo01 -->
         <exclude>org.apache.poi:poi-ooxml:[3.8]</exclude>
+        <!-- Avoid any direct addon inclusion on the distribution packages -->
+        <exclude>org.exoplatform.addons.*:*</exclude>
       </excludes>
       <outputFileNameMapping>${artifact.artifactId}-${artifact.baseVersion}.${artifact.extension}</outputFileNameMapping>
       <useProjectArtifact>false</useProjectArtifact>


### PR DESCRIPTION
…n packages by the assembly

This assembly file is used on the private distribution packaging. Setting this here will ensure there is no addon artifacts included on the final distributions packages too.