### PR TITLE
PLF-8240 : do not display Tomcat version in error page

### DIFF
--- a/plf-tomcat-resources/src/main/resources/conf/context.xml
+++ b/plf-tomcat-resources/src/main/resources/conf/context.xml
@@ -36,6 +36,7 @@
   <Manager pathname="" />
 
   <Valve className="org.gatein.sso.agent.tomcat.ServletAccessValve" asyncSupported="true"/>
+  <Valve className="org.apache.catalina.valves.ErrorReportValve" showReport="false" showServerInfo="false"/>
   <!-- Uncomment this to enable Comet connection tacking (provides events
          on session expiration as well as webapp lifecycle) -->
   <!--


### PR DESCRIPTION
The Tomcat default error page is used in case of error. It discloses the server version, which could help attacking the platform.

This fix adds the valve org.apache.catalina.valves.ErrorReportValve and sets its attribute showServerInfo to false to not display the server version.

Notes: I initially wanted to use custom error pages, but it required to add them in everyday webapps (including addons). This would result in a lot of duplicated files, without big benefits compared to the current solution. WDYT ?