### PR TITLE
 PLF-8119 : Add JDK 11 support 

### DIFF
--- a/plf-assemblies/src/main/resources/assemblies/plf-copy-libraries-component.xml
+++ b/plf-assemblies/src/main/resources/assemblies/plf-copy-libraries-component.xml
@@ -81,7 +81,6 @@
         <exclude>org.apache.geronimo.specs:geronimo-stax-api_1.0_spec</exclude>
         <exclude>stax:*</exclude>
         <exclude>javax.xml.stream:*</exclude>
-        <exclude>javax.activation:*</exclude>
         <exclude>org.apache.geronimo.specs:geronimo-activation_1.0.2_spec</exclude>
         <exclude>org.jboss.javaee:jboss-transaction-api</exclude>
         <exclude>org.jboss.spec.javax.transaction:*</exclude>
@@ -90,8 +89,6 @@
         <exclude>rome:modules:*</exclude>
         <!-- this is a build resource -->
         <exclude>org.exoplatform.resources:exo-lgpl-license-resource-bundle:*</exclude>
-        <!-- PLF-4963 : Don't package any jaxb dep to avoid conflicts with the version provided in Java 6 -->
-        <exclude>*:jaxb*:*</exclude>
         <!-- Don't package any XML APIs dep to avoid conflicts the JVM -->
         <exclude>*:xmlParserAPIs:*</exclude>
         <!-- PLF-6122: Exclude icepdf older than 5.1.0. The groupId for Open Source bundles is now org.icepdf.os -->

--- a/plf-dependencies/pom.xml
+++ b/plf-dependencies/pom.xml
@@ -65,11 +65,6 @@
           <artifactId>log4j</artifactId>
           <groupId>log4j</groupId>
         </exclusion>
-        <!-- Coming by transitivity from javax.mail:mail -->
-        <exclusion>
-          <artifactId>activation</artifactId>
-          <groupId>javax.activation</groupId>
-        </exclusion>
         <!-- Coming by transitivity from com.thoughtworks.xstream:xstream -->
         <exclusion>
           <artifactId>xpp3_min</artifactId>
@@ -94,11 +89,6 @@
         <exclusion>
           <artifactId>stax-api</artifactId>
           <groupId>javax.xml.stream</groupId>
-        </exclusion>
-        <!-- Coming by transitivity from org.picketlink.idm:picketlink-idm-core -->
-        <exclusion>
-          <artifactId>jaxb-impl</artifactId>
-          <groupId>com.sun.xml.bind</groupId>
         </exclusion>
         <!-- Coming by transitivity from org.exoplatform.gatein.portal:exo.portal.webui.portal -->
         <exclusion>
@@ -438,11 +428,6 @@
           <artifactId>xpp3_min</artifactId>
           <groupId>xpp3</groupId>
         </exclusion>
-        <!-- Coming by transitivity from org.exoplatform.ws:exo.ws.rest.coree -->
-        <exclusion>
-          <artifactId>activation</artifactId>
-          <groupId>javax.activation</groupId>
-        </exclusion>
         <!-- Coming by transitivity from org.exoplatform.gatein.sso:sso-saml-plugin -->
         <exclusion>
           <artifactId>javax.servlet-api</artifactId>
@@ -678,13 +663,6 @@
     <dependency>
       <groupId>org.exoplatform.gatein.portal</groupId>
       <artifactId>exo.portal.component.management</artifactId>
-      <exclusions>
-        <!-- Coming by transitivity from org.exoplatform.ws:exo.ws.rest.core -->
-        <exclusion>
-          <artifactId>activation</artifactId>
-          <groupId>javax.activation</groupId>
-        </exclusion>
-      </exclusions>
     </dependency>
     <!-- org.gatein.security.oauth.webapi.OAuthDelegateFilter used but not declared in GateIn ? -->
     <dependency>

--- a/plf-exo-tools/pom.xml
+++ b/plf-exo-tools/pom.xml
@@ -32,7 +32,7 @@
   <packaging>jar</packaging>
   <name>eXo PLF:: Platform Public Distributions - eXo Tools</name>
   <properties>
-    <exo.test.coverage.ratio>0.35</exo.test.coverage.ratio>
+    <exo.test.coverage.ratio>0.47</exo.test.coverage.ratio>
   </properties>
   <dependencies>
     <dependency>

--- a/plf-exo-tools/src/main/java/org/exoplatform/distributions/tools/ExoTools.java
+++ b/plf-exo-tools/src/main/java/org/exoplatform/distributions/tools/ExoTools.java
@@ -36,15 +36,19 @@ package org.exoplatform.distributions.tools;
 public final class ExoTools {
 
   /** Java Version from the system */
-  public static final String systemJavaVersion  = System.getProperty("java.version");
+  public static final String systemJavaVersion   = System.getProperty("java.version");
 
-  public static final String CMD_JAVA_8         = "isJava8";
+  public static final String CMD_JAVA_8          = "isJava8";
 
-  public static final String CMD_JAVA_8_OR_MORE = "isJava8OrSuperior";
+  public static final String CMD_JAVA_8_OR_MORE  = "isJava8OrSuperior";
 
-  public static final String CMD_JAVA_9         = "isJava9";
+  public static final String CMD_JAVA_9          = "isJava9";
 
-  public static final String CMD_JAVA_9_OR_MORE = "isJava9OrSuperior";
+  public static final String CMD_JAVA_9_OR_MORE  = "isJava9OrSuperior";
+
+  public static final String CMD_JAVA_11         = "isJava11";
+
+  public static final String CMD_JAVA_11_OR_MORE = "isJava11OrSuperior";
 
   /**
    * eXo Tools entrypoint.
@@ -79,6 +83,10 @@ public final class ExoTools {
         return javaVersion.isMajorVersionEqual(9);
       case CMD_JAVA_9_OR_MORE:
         return javaVersion.isMajorVersionSuperiorOrEqual(9);
+      case CMD_JAVA_11:
+        return javaVersion.isMajorVersionEqual(11);
+      case CMD_JAVA_11_OR_MORE:
+        return javaVersion.isMajorVersionSuperiorOrEqual(11);
       default:
         return -1;
     }

--- a/plf-exo-tools/src/main/java/org/exoplatform/distributions/tools/JavaVersion.java
+++ b/plf-exo-tools/src/main/java/org/exoplatform/distributions/tools/JavaVersion.java
@@ -62,12 +62,15 @@ class JavaVersion {
     try {
       Matcher regexMatcher = regex.matcher(systemJavaVersion);
       if (regexMatcher.find()) {
-        systemJavaMajorVersion = Integer.parseInt(regexMatcher.group(1));
-        String minorVersion = regexMatcher.group(2);
-        if(minorVersion != null) {
-          systemJavaMinorVersion = Integer.parseInt(minorVersion);
-        } else if(systemJavaMajorVersion == 9) {
+        String strSystemJavaMajorVersion = regexMatcher.group(1);
+        systemJavaMajorVersion = Integer.parseInt(strSystemJavaMajorVersion);
+        if(strSystemJavaMajorVersion.equals(systemJavaVersion)) {
           systemJavaMinorVersion = 0;
+        } else {
+          String minorVersion = regexMatcher.group(2);
+          if (minorVersion != null) {
+            systemJavaMinorVersion = Integer.parseInt(minorVersion);
+          }
         }
       }
     } catch (Exception ex){

--- a/plf-exo-tools/src/test/java/org/exoplatform/distributions/tools/JavaVersionTest.java
+++ b/plf-exo-tools/src/test/java/org/exoplatform/distributions/tools/JavaVersionTest.java
@@ -22,7 +22,7 @@ package org.exoplatform.distributions.tools;
 
 import org.junit.Test;
 
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.*;
 
 
 public class JavaVersionTest {
@@ -82,5 +82,48 @@ public class JavaVersionTest {
     assertTrue(jv.isMinorVersionEqual(0) == 0);
     assertTrue(jv.isMinorVersionSuperiorOrEqual(8) == -1);
     assertTrue(jv.isMajorVersionSuperiorOrEqual(9) == 0);
+  }
+
+  @Test
+  public final void testJava11Version(){
+    JavaVersion jv = new JavaVersion("11");
+
+    assertTrue(jv.isMinorVersionEqual(8) == -1);
+    assertTrue(jv.isMajorVersionEqual(9) == -1);
+    assertTrue(jv.isMajorVersionEqual(11) == 0);
+    assertTrue(jv.isMajorVersionSuperiorOrEqual(11) == 0);
+
+    jv = new JavaVersion("11.0");
+    assertTrue(jv.isMinorVersionEqual(8) == -1);
+    assertTrue(jv.isMajorVersionEqual(9) == -1);
+    assertTrue(jv.isMajorVersionEqual(11) == 0);
+    assertTrue(jv.isMinorVersionEqual(0) == 0);
+    assertTrue(jv.isMinorVersionSuperiorOrEqual(8) == -1);
+    assertTrue(jv.isMajorVersionSuperiorOrEqual(9) == 0);
+    assertTrue(jv.isMajorVersionSuperiorOrEqual(11) == 0);
+
+    jv = new JavaVersion("11.0.1");
+    assertTrue(jv.isMinorVersionEqual(8) == -1);
+    assertTrue(jv.isMajorVersionEqual(9) == -1);
+    assertTrue(jv.isMajorVersionEqual(11) == 0);
+    assertTrue(jv.isMinorVersionEqual(0) == 0);
+    assertTrue(jv.isMinorVersionSuperiorOrEqual(8) == -1);
+    assertTrue(jv.isMajorVersionSuperiorOrEqual(9) == 0);
+    assertTrue(jv.isMajorVersionSuperiorOrEqual(11) == 0);
+  }
+
+  @Test
+  public void testEquals() {
+    JavaVersion jv825 = new JavaVersion("1.8.0_25");
+    JavaVersion jv845 = new JavaVersion("1.8.0_45");
+    JavaVersion jv11 = new JavaVersion("11");
+    JavaVersion jv1101 = new JavaVersion("11.0.1");
+
+    assertEquals(jv825, jv825);
+    assertEquals(jv825, jv845);
+    assertEquals(jv825, jv845);
+    assertNotEquals(jv825, new Object());
+    assertEquals(jv11, jv1101);
+    assertNotEquals(jv825, jv1101);
   }
 }

--- a/plf-tomcat-resources/src/main/resources/bin/setenv.bat
+++ b/plf-tomcat-resources/src/main/resources/bin/setenv.bat
@@ -179,8 +179,16 @@ SET CATALINA_OPTS=%CATALINA_OPTS% -Djava.util.Arrays.useLegacyMergeSort=true
 REM # PLF-6965 # set default file encoding to UTF-8 Independently from OS default charset
 SET CATALINA_OPTS=%CATALINA_OPTS% -Dfile.encoding="UTF-8"
 
+SET javaExec=java.exe
+IF DEFINED JAVA_HOME (
+  SET javaExec="%JAVA_HOME%\bin\java.exe"
+)
+
 REM # Used JDK_JAVA_OPTIONS for JDK 9 options since this variable is only recognized by JDK 9+
-SET JDK_JAVA_OPTIONS=--add-modules java.activation --add-modules java.xml.bind
+%javaExec% -jar %CATALINA_HOME%\bin\exo-tools.jar isJava11OrSuperior
+IF ERRORLEVEL 1 (
+  SET JDK_JAVA_OPTIONS=%JDK_JAVA_OPTIONS% --add-modules java.activation --add-modules java.xml.bind
+)
 REM # Open all required modules for reflective access operations
 SET JDK_JAVA_OPTIONS=%JDK_JAVA_OPTIONS% --add-opens java.base/java.io=ALL-UNNAMED
 SET JDK_JAVA_OPTIONS=%JDK_JAVA_OPTIONS% --add-opens java.base/java.lang=ALL-UNNAMED

--- a/plf-tomcat-resources/src/main/resources/bin/setenv.sh
+++ b/plf-tomcat-resources/src/main/resources/bin/setenv.sh
@@ -185,8 +185,13 @@ CATALINA_OPTS="$CATALINA_OPTS -Djava.security.egd=file:/dev/./urandom"
 # PLF-6965 set default file encoding to UTF-8 Independently from OS default charset
 CATALINA_OPTS="$CATALINA_OPTS -Dfile.encoding=UTF-8"
 
+javaExec=java
+if [ ! -z "$JAVA_HOME" ]; then
+  javaExec=$JAVA_HOME/bin/java
+fi
+
 # Used JDK_JAVA_OPTIONS for JDK 9+ options since this variable is only recognized by JDK 9+
-cmd=$(java -jar $CATALINA_HOME/bin/exo-tools.jar isJava11OrSuperior)
+cmd=$($javaExec -jar $CATALINA_HOME/bin/exo-tools.jar isJava11OrSuperior)
 if [ $? != 0 ]; then
   JDK_JAVA_OPTIONS="--add-modules java.activation --add-modules java.xml.bind"
 fi

--- a/plf-tomcat-resources/src/main/resources/bin/setenv.sh
+++ b/plf-tomcat-resources/src/main/resources/bin/setenv.sh
@@ -185,8 +185,11 @@ CATALINA_OPTS="$CATALINA_OPTS -Djava.security.egd=file:/dev/./urandom"
 # PLF-6965 set default file encoding to UTF-8 Independently from OS default charset
 CATALINA_OPTS="$CATALINA_OPTS -Dfile.encoding=UTF-8"
 
-# Used JDK_JAVA_OPTIONS for JDK 9 options since this variable is only recognized by JDK 9+
-JDK_JAVA_OPTIONS="--add-modules java.activation --add-modules java.xml.bind"
+# Used JDK_JAVA_OPTIONS for JDK 9+ options since this variable is only recognized by JDK 9+
+cmd=$(java -jar $CATALINA_HOME/bin/exo-tools.jar isJava11OrSuperior)
+if [ $? != 0 ]; then
+  JDK_JAVA_OPTIONS="--add-modules java.activation --add-modules java.xml.bind"
+fi
 # Open all required modules for reflective access operations
 JDK_JAVA_OPTIONS="$JDK_JAVA_OPTIONS --add-opens java.base/java.io=ALL-UNNAMED"
 JDK_JAVA_OPTIONS="$JDK_JAVA_OPTIONS --add-opens java.base/java.lang=ALL-UNNAMED"

--- a/pom.xml
+++ b/pom.xml
@@ -359,15 +359,12 @@
                         <exclude>org.apache.geronimo.specs:geronimo-stax-api_1.0_spec</exclude>
                         <exclude>stax:*</exclude>
                         <exclude>javax.xml.stream:*</exclude>
-                        <exclude>javax.activation:*</exclude>
                         <exclude>org.apache.geronimo.specs:geronimo-activation_1.0.2_spec</exclude>
                         <exclude>org.jboss.javaee:jboss-transaction-api</exclude>
                         <exclude>org.jboss.spec.javax.transaction:*</exclude>
                         <exclude>org.ow2.spec.ee:ow2-jta-1.1-spec</exclude>
                         <!-- PLF-4528 / CAL-148 : Conflict with com.totsp.feedpod:itunes-com-podcast -->
                         <exclude>rome:modules:*</exclude>
-                        <!-- PLF-4963 : Don't package any jaxb dep to avoid conflicts with the version provided in Java 6 -->
-                        <exclude>*:jaxb*:*</exclude>
                         <!-- Don't package any XML APIs dep to avoid conflicts the JVM -->
                         <exclude>*:xmlParserAPIs:*</exclude>
                         <!-- PLF-6122: Exclude icepdf older than 5.1.0. The groupId for Open Source bundles is now org.icepdf.os -->


### PR DESCRIPTION
Adds JDK 11 support by:
* improving exo-tools to support version 11 of JDK
* do not exclude anymore activation and jaxb dependencies since they are not bundled in the JDK anymore and therefore must be added in PLF classpath