### PR TITLE
PLF-8371 Activate the RemoteIpValve to help tomcat to detect if ssl i…

### DIFF
--- a/plf-tomcat-resources/src/main/resources/conf/server.template.xml
+++ b/plf-tomcat-resources/src/main/resources/conf/server.template.xml
@@ -192,6 +192,9 @@
                prefix="localhost_access_log" suffix=".txt"
                pattern="%h %l %u %t &quot;%r&quot; %s %b" />
         -->
+
+        <!-- Be aware of the reverse proxy environment -->
+        <Valve className="org.apache.catalina.valves.RemoteIpValve" remoteIpHeader="x-forwarded-for" proxiesHeader="x-forwarded-by" protocolHeader="x-forwarded-proto" />
       </Host>
     </Engine>
   </Service>


### PR DESCRIPTION
…s used or not

It will help to detect the environment with the default configuration and without manipulating the connector configuration.
