### PR TITLE
PLF-8688 Define all product core extension wars in central JAR configuration file

### DIFF
--- a/plf-configuration/src/main/resources/conf/platform/configuration.xml
+++ b/plf-configuration/src/main/resources/conf/platform/configuration.xml
@@ -75,6 +75,36 @@
                <value>
                   <string>eXoResources</string>
                </value>
+               <value>
+                  <string>commons-extension</string>
+               </value>
+               <value>
+                  <string>cometd</string>
+               </value>
+               <value>
+                  <string>welcome-screens</string>
+               </value>
+               <value>
+                  <string>social-extension</string>
+               </value>
+               <value>
+                  <string>social-notification-extension</string>
+               </value>
+               <value>
+                  <string>social-resources</string>
+               </value>
+               <value>
+                  <string>social-portlet</string>
+               </value>
+               <value>
+                  <string>social-juzu</string>
+               </value>
+               <value>
+                  <string>social-vue-portlet</string>
+               </value>
+               <value>
+                  <string>unified-search</string>
+               </value>
             </collection>
           </field>
 


### PR DESCRIPTION
The lightweight Feature (PLF-8617) has applied a new strategy to load extensions using "META-INF/exo-conf/configuration.xml". This system has a drawback which is that the WAR file has to be deployed and available before "RootContainer startup". Thus, in web.xml file of extension, we shouldn't add servlets nor additional elements that may make the WAR loading slower.
In this issue, the problem will be solved by simply reapply old way of configuration by declaring basic extension files in RootContainer configuration file retrieved from JAR.