### PR TITLE
PLF-8698 Add htmlcleaner JAR in common CE distrib

### DIFF
--- a/plf-dependencies/pom.xml
+++ b/plf-dependencies/pom.xml
@@ -234,6 +234,10 @@
       <type>war</type>
     </dependency>
     <dependency>
+      <groupId>net.sourceforge.htmlcleaner</groupId>
+      <artifactId>htmlcleaner</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.apache.portals.bridges</groupId>
       <artifactId>portals-bridges-common</artifactId>
     </dependency>


### PR DESCRIPTION
htmlcleaner jar is used by news and wiki, thus it will be added in common CE distribution instead of addon.