### PR TITLE
PLF-8712 Avoid executing PortalRequestHandler for resources URL

### DIFF
--- a/plf-packaging-resources/src/main/resources/controller.xml
+++ b/plf-packaging-resources/src/main/resources/controller.xml
@@ -69,6 +69,53 @@
     </route-param>
   </route>  
 
+  <!-- Skin handler -->
+  <route path="/skins/{gtn:version}/{gtn:resource}{gtn:compress}{gtn:orientation}.css">
+    <route-param qname="gtn:handler">
+      <value>skin</value>
+    </route-param>
+    <path-param qname="gtn:version" encoding="preserve-path">
+      <pattern>[^/]*</pattern>
+    </path-param>
+    <path-param qname="gtn:compress" capture-group="true">
+      <pattern>-(min)|</pattern>
+    </path-param>
+    <path-param qname="gtn:orientation" capture-group="true">
+      <pattern>-(lt)|-(rt)|</pattern>
+    </path-param>
+    <path-param qname="gtn:resource" encoding="preserve-path">
+      <pattern>.+?</pattern>
+    </path-param>
+  </route>
+
+  <!-- Script handler -->
+  <route path="/scripts/{gtn:version}/{gtn:scope}/">
+    <route-param qname="gtn:handler">
+      <value>script</value>
+    </route-param>
+    <path-param qname="gtn:version" encoding="preserve-path">
+      <pattern>[^/]*</pattern>
+    </path-param>
+    <route path="/{gtn:resource}{gtn:lang}{gtn:compress}.js">
+      <path-param qname="gtn:resource">
+        <pattern>.+?</pattern>
+      </path-param>
+      <path-param qname="gtn:lang" capture-group="true">
+        <pattern>-((ar|ar-AE|ar-BH|ar-DZ|ar-EG|ar-IQ|ar-JO|ar-KW|ar-LB|ar-LY|ar-MA|ar-OM|ar-QA|ar-SA|ar-SD|ar-SY|ar-TN|ar-YE|be|be-BY|bg|bg-BG|ca|ca-ES|cs|cs-CZ|da|da-DK|de|de-AT|de-CH|de-DE|de-GR|de-LU|el|el-CY|el-GR|en|en-AU|en-CA|en-GB|en-IE|en-IN|en-MT|en-NZ|en-PH|en-SG|en-US|en-ZA|es|es-AR|es-BO|es-CL|es-CO|es-CR|es-CU|es-DO|es-EC|es-ES|es-GT|es-HN|es-MX|es-NI|es-PA|es-PE|es-PR|es-PY|es-SV|es-US|es-UY|es-VE|et|et-EE|fa|fi|fi-FI|fil|fr|fr-BE|fr-CA|fr-CH|fr-FR|fr-LU|ga|ga-IE|hi|hi-IN|hr|hr-HR|hu|hu-HU|in|in-ID|is|is-IS|it|it-CH|it-IT|iw|iw-IL|ja|ja-JP|ja-JP-JP-#u-ca-japanese|ko|ko-KR|lt|lt-LT|lv|lv-LV|mk|mk-MK|ms|ms-MY|mt|mt-MT|nl|nl-BE|nl-NL|no|no-NO|no-NO-NY|pl|pl-PL|pt|pt-BR|pt-PT|ro|ro-RO|ru|ru-RU|sk|sk-SK|sl|sl-SI|sq|sq-AL|sr|sr-BA|sr-BA-#Latn|sr-CS|sr-ME|sr-ME-#Latn|sr-RS|sr-RS-#Latn|sr--#Latn|sv|sv-SE|th|th-TH|th-TH-TH-#u-nu-thai|tr|tr-TR|uk|uk-UA|vi|vi-VN|zh|zh-CN|zh-HK|zh-SG|zh-TW)?)|</pattern>
+      </path-param>
+      <path-param qname="gtn:compress" capture-group="true">
+        <pattern>-(min)|</pattern>
+      </path-param>
+    </route>
+  </route>
+
+  <!-- ECMS Sites JS files -->
+  <route path="/javascript/{gtn:sitename}.js">
+    <route-param qname="gtn:handler">
+      <value>javascript</value>
+    </route-param>
+  </route>
+
   <!-- The legacy route -->
   <route path="/public">
     <route path="/">
@@ -99,32 +146,6 @@
         <pattern>.*</pattern>
       </path-param>
     </route>
-  </route>
-
-  <!-- Skin handler -->
-  <route path="/skins/{gtn:version}/{gtn:resource}{gtn:compress}{gtn:orientation}.css">
-    <route-param qname="gtn:handler">
-      <value>skin</value>
-    </route-param>
-    <path-param qname="gtn:version" encoding="preserve-path">
-      <pattern>[^/]*</pattern>
-    </path-param>
-    <path-param qname="gtn:compress" capture-group="true">
-      <pattern>-(min)|</pattern>
-    </path-param>
-    <path-param qname="gtn:orientation" capture-group="true">
-      <pattern>-(lt)|-(rt)|</pattern>
-    </path-param>
-    <path-param qname="gtn:resource" encoding="preserve-path">
-      <pattern>.+?</pattern>
-    </path-param>
-  </route>
-
-  <!-- ECMS Sites JS files -->
-  <route path="/javascript/{gtn:sitename}.js">
-    <route-param qname="gtn:handler">
-      <value>javascript</value>
-    </route-param>
   </route>
 
   <!-- Static resource handler needs to be before the portal handler -->
@@ -206,27 +227,6 @@
       </path-param>
     </route>
 
-  </route>
-
-  <!-- Script handler -->
-  <route path="/scripts/{gtn:version}/{gtn:scope}/">
-    <route-param qname="gtn:handler">
-      <value>script</value>
-    </route-param>
-    <path-param qname="gtn:version" encoding="preserve-path">
-      <pattern>[^/]*</pattern>
-    </path-param>
-    <route path="/{gtn:resource}{gtn:lang}{gtn:compress}.js">
-      <path-param qname="gtn:resource">
-        <pattern>.+?</pattern>
-      </path-param>
-      <path-param qname="gtn:lang" capture-group="true">
-        <pattern>-((ar|ar-AE|ar-BH|ar-DZ|ar-EG|ar-IQ|ar-JO|ar-KW|ar-LB|ar-LY|ar-MA|ar-OM|ar-QA|ar-SA|ar-SD|ar-SY|ar-TN|ar-YE|be|be-BY|bg|bg-BG|ca|ca-ES|cs|cs-CZ|da|da-DK|de|de-AT|de-CH|de-DE|de-GR|de-LU|el|el-CY|el-GR|en|en-AU|en-CA|en-GB|en-IE|en-IN|en-MT|en-NZ|en-PH|en-SG|en-US|en-ZA|es|es-AR|es-BO|es-CL|es-CO|es-CR|es-CU|es-DO|es-EC|es-ES|es-GT|es-HN|es-MX|es-NI|es-PA|es-PE|es-PR|es-PY|es-SV|es-US|es-UY|es-VE|et|et-EE|fa|fi|fi-FI|fil|fr|fr-BE|fr-CA|fr-CH|fr-FR|fr-LU|ga|ga-IE|hi|hi-IN|hr|hr-HR|hu|hu-HU|in|in-ID|is|is-IS|it|it-CH|it-IT|iw|iw-IL|ja|ja-JP|ja-JP-JP-#u-ca-japanese|ko|ko-KR|lt|lt-LT|lv|lv-LV|mk|mk-MK|ms|ms-MY|mt|mt-MT|nl|nl-BE|nl-NL|no|no-NO|no-NO-NY|pl|pl-PL|pt|pt-BR|pt-PT|ro|ro-RO|ru|ru-RU|sk|sk-SK|sl|sl-SI|sq|sq-AL|sr|sr-BA|sr-BA-#Latn|sr-CS|sr-ME|sr-ME-#Latn|sr-RS|sr-RS-#Latn|sr--#Latn|sv|sv-SE|th|th-TH|th-TH-TH-#u-nu-thai|tr|tr-TR|uk|uk-UA|vi|vi-VN|zh|zh-CN|zh-HK|zh-SG|zh-TW)?)|</pattern>
-      </path-param>
-      <path-param qname="gtn:compress" capture-group="true">
-        <pattern>-(min)|</pattern>
-      </path-param>
-    </route>
   </route>
 
   <!-- Default handler -->


### PR DESCRIPTION
PortalRequestHandler is used to handle portal requests only. Thus no need to parse "/portal/scripts/***"  URLs as Portal requests but as ResourceRequestHandler (script). Thus the order of handlers have been optimized to reduce calls on DB inefficiently.