### PR TITLE
MAINT-26915 : Force using UTF-8 for IDM database connection

### DIFF
--- a/plf-tomcat-resources/src/main/resources/conf/server.template.xml
+++ b/plf-tomcat-resources/src/main/resources/conf/server.template.xml
@@ -63,7 +63,7 @@
               testWhileIdle="true" testOnBorrow="true" testOnReturn="false"
               timeBetweenEvictionRunsMillis="30000" minEvictableIdleTimeMillis="60000"
               removeAbandonedOnBorrow="true" removeAbandonedOnMaintenance="true" removeAbandonedTimeout="300" logAbandoned="false"
-              username="${username}" password="${password}" driverClassName="${driverClassName}" url="${url}${connectionParameters}" />
+              username="${username}" password="${password}" driverClassName="${driverClassName}" url="${url}${jpaConnectionParameters}" />
 
     <!-- eXo JCR Datasource for portal -->
     <Resource name="exo-jcr_portal" auth="Container" type="javax.sql.DataSource"


### PR DESCRIPTION
When adding users with cyrillic charcters, those users loose their firstname/lastname and all charcters become ?
The fix will add the parameter characterEncoding to IDM connection to make sure the UTF-8 encoding will be used by the driver when communicating with the Mysql Server. for more information see https://dev.mysql.com/doc/connector-j/8.0/en/connector-j-reference-charsets.html