### PR TITLE
TASK-58665: Change the exo community edition default branding name 

### DIFF
--- a/services/src/main/resources/platform-community-configuration.properties
+++ b/services/src/main/resources/platform-community-configuration.properties
@@ -1,8 +1,8 @@
 # Branding configuration
-exo.branding.company.name=Digital Workplace
+exo.branding.company.name=eXo Community Edition
 exo.branding.company.siteName=eXo Platform
 exo.branding.company.link=https://exoplatform.com
-exo.branding.company.logo=
+exo.branding.company.logo=/logo/Logo.png
 exo.branding.theme.path=
 exo.branding.theme.primaryColor=primaryColor:#476A9C
 exo.branding.theme.secondaryColor=secondaryColor:#476a9c


### PR DESCRIPTION
This fix will
 - Change exo community edition default branding name from digital workplace to eXo Community Edition
 - Fix the default logo path