### PR TITLE
fix : Server do not start if we remove wallet addon - EXO-60702

### DIFF
--- a/packaging/src/main/assemblies/platform-community-tomcat-zip-content.xml
+++ b/packaging/src/main/assemblies/platform-community-tomcat-zip-content.xml
@@ -55,6 +55,9 @@
         <include>io.jsonwebtoken:jjwt-api:jar</include>
         <include>io.jsonwebtoken:jjwt-impl:jar</include>
         <include>io.jsonwebtoken:jjwt-jackson:jar</include>
+        <include>com.fasterxml.jackson.core:jackson-databind:jar</include>
+        <include>com.fasterxml.jackson.core:jackson-annotations:jar</include>
+        <include>com.fasterxml.jackson.core:jackson-core:jar</include>
       </includes>
       <scope>provided</scope>
       <outputFileNameMapping>${artifact.artifactId}.jar</outputFileNameMapping>


### PR DESCRIPTION
Before this fix, the wallet packaging contains the jar jackson-databind which is needed by other part of the platform. When the addon is uninstall because not needed, the jar is removed. In addition, this jar is not needed for wallet addon As the jar is removed in wallet addon, we need to add it in plf packaging, as it is needed by onlyoffice addon and webconferencing addon.