### PR TITLE
fix : Server do not start if we remove wallet addon - EXO-60702

### DIFF
--- a/packaging/src/main/assemblies/platform-community-tomcat-zip-content.xml
+++ b/packaging/src/main/assemblies/platform-community-tomcat-zip-content.xml
@@ -55,9 +55,6 @@
         <include>io.jsonwebtoken:jjwt-api:jar</include>
         <include>io.jsonwebtoken:jjwt-impl:jar</include>
         <include>io.jsonwebtoken:jjwt-jackson:jar</include>
-        <include>com.fasterxml.jackson.core:jackson-databind:jar</include>
-        <include>com.fasterxml.jackson.core:jackson-annotations:jar</include>
-        <include>com.fasterxml.jackson.core:jackson-core:jar</include>
       </includes>
       <scope>provided</scope>
       <outputFileNameMapping>${artifact.artifactId}.jar</outputFileNameMapping>


### PR DESCRIPTION
Before this fix, the wallet packaging contains the jar jackson-databind which is needed by other part of the platform. When the addon is uninstall because not needed, the jar is removed. We initially put the dependencies at exoplatform level. But theses dependencies are needed by wallet addons. So it is moved to meeds build package and removed from platform build package