### PR TITLE
feat: introduce eXo parent pom - EXO-64103

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,9 +20,9 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
-    <artifactId>maven-parent-pom</artifactId>
+    <artifactId>maven-exo-parent-pom</artifactId>
     <groupId>org.exoplatform</groupId>
-    <version>25-exo-M06</version>
+    <version>26-M01</version>
     <relativePath />
   </parent>
   <groupId>org.exoplatform.platform.distributions</groupId>


### PR DESCRIPTION
This feature introduce new parent pom for eXo to be able to declare libraries versions used only in eXo, without impacting meeds