### PR TITLE
feat: Apply default property values for platform access - Meeds-io/MIPs#63

### DIFF
--- a/packaging/src/main/resources/gatein/conf/exo-sample.properties
+++ b/packaging/src/main/resources/gatein/conf/exo-sample.properties
@@ -1242,3 +1242,9 @@
 
 # Enable/Disable main stream composer
 #exo.config.mainStreamComposer.enabled=false
+
+# Platform Access
+#
+#Properties to define platform access
+#meeds.settings.access.type.default=restricted
+#meeds.settings.access.externalUsers=true

--- a/services/src/main/resources/platform-community-configuration.properties
+++ b/services/src/main/resources/platform-community-configuration.properties
@@ -19,3 +19,7 @@ exo.activity-type.files\:spaces.UPDATE_COMMENT.enabled=${exo.activity-type.files
 exo.activity-type.files\:spaces.TAG_ACTION_COMMENT.enabled=${exo.activity-type.files-spaces.TAG_ACTION_COMMENT.enabled:false}
 ## Add an activity if a content is created
 exo.activity-type.contents\:spaces.enabled=${exo.activity-type.contents-spaces.enabled:false}
+
+#Properties to define platform access
+meeds.settings.access.type.default=restricted
+meeds.settings.access.externalUsers=true


### PR DESCRIPTION
This change apply the default value for platform access for exo side. By default the platform have restricted access
By default, users invited in spaces are added in externals group